### PR TITLE
로그 기능 구현

### DIFF
--- a/src/main/java/com/maeng0830/album/common/aop/AopConfig.java
+++ b/src/main/java/com/maeng0830/album/common/aop/AopConfig.java
@@ -1,0 +1,20 @@
+package com.maeng0830.album.common.aop;
+
+import com.maeng0830.album.common.aop.aspect.LoggingAspect;
+import com.maeng0830.album.common.logging.LogTrace;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AopConfig {
+
+	@Bean
+	public LogTrace logTrace() {
+		return new LogTrace();
+	}
+
+	@Bean
+	public LoggingAspect loggingAspect() {
+		return new LoggingAspect(logTrace());
+	}
+}

--- a/src/main/java/com/maeng0830/album/common/aop/Pointcuts.java
+++ b/src/main/java/com/maeng0830/album/common/aop/Pointcuts.java
@@ -1,0 +1,18 @@
+package com.maeng0830.album.common.aop;
+
+import org.aspectj.lang.annotation.Pointcut;
+
+public class Pointcuts {
+
+	@Pointcut("execution(public * com.maeng0830.album..*Repository*.*(..))")
+	public void allRepository() {}
+
+	@Pointcut("execution(public * com.maeng0830.album..*Service*.*(..))")
+	public void allService() {}
+
+	@Pointcut("execution(public * com.maeng0830.album..*Controller*.*(..))")
+	public void allController() {}
+
+	@Pointcut("allRepository() || allService() || allController()")
+	public void allMatch() {}
+}

--- a/src/main/java/com/maeng0830/album/common/aop/aspect/LoggingAspect.java
+++ b/src/main/java/com/maeng0830/album/common/aop/aspect/LoggingAspect.java
@@ -1,0 +1,38 @@
+package com.maeng0830.album.common.aop.aspect;
+
+import com.maeng0830.album.common.logging.LogStatus;
+import com.maeng0830.album.common.logging.LogTrace;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+
+@Aspect
+public class LoggingAspect {
+
+	private static final String POINTCUT_PACKAGE = "com.maeng0830.album.common.aop.Pointcuts.";
+	private final LogTrace logTrace;
+
+	public LoggingAspect(LogTrace logTrace) {
+		this.logTrace = logTrace;
+	}
+
+	@Around(POINTCUT_PACKAGE + "allMatch()")
+	public Object doLog(ProceedingJoinPoint joinPoint) throws Throwable {
+		LogStatus logStatus = null;
+
+		try {
+			String message = joinPoint.getSignature().toShortString();
+
+			logStatus = logTrace.begin(message); // 현재 메소드 호출 로깅
+
+			Object result = joinPoint.proceed();// 현재 메소드 호출
+
+			logTrace.end(logStatus); // 현재 메소드 정상 종료 로깅
+
+			return result;
+		} catch (Exception e) {
+			logTrace.exception(logStatus, e); // 현재 메소드 예외 종료 로깅
+			throw e;
+		}
+	}
+}

--- a/src/main/java/com/maeng0830/album/common/logging/LogId.java
+++ b/src/main/java/com/maeng0830/album/common/logging/LogId.java
@@ -1,0 +1,40 @@
+package com.maeng0830.album.common.logging;
+
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class LogId {
+	// 로그 아이디. http 클라이언트 요청 별로 동일한 값 유지
+	private final String id;
+	// 메소드 호출 깊이. ex) memberController.method() -> memberService.method() -> MemberRepository.method()
+	private final int depth;
+
+	public LogId() {
+		this.depth = 0;
+		this.id = createId();
+	}
+
+	// createNext(), createPrev()를 위한 생성자
+	private LogId(String id, int depth) {
+		this.id = id;
+		this.depth = depth;
+	}
+
+	// 로그 아이디 생성
+	private String createId() {
+		return UUID.randomUUID().toString().substring(0, 8);
+	}
+
+	public LogId createNext() {
+		return new LogId(id, depth + 1);
+	}
+
+	public LogId createPrev() {
+		return new LogId(id, depth - 1);
+	}
+
+	public boolean isZeroDepth() {
+		return depth == 0;
+	}
+}

--- a/src/main/java/com/maeng0830/album/common/logging/LogStatus.java
+++ b/src/main/java/com/maeng0830/album/common/logging/LogStatus.java
@@ -1,0 +1,17 @@
+package com.maeng0830.album.common.logging;
+
+import lombok.Getter;
+
+@Getter
+public class LogStatus {
+
+	private final LogId logId;
+	private final Long startTime;
+	private final String message;
+
+	public LogStatus(LogId logId, Long startTime, String message) {
+		this.logId = logId;
+		this.startTime = startTime;
+		this.message = message;
+	}
+}

--- a/src/main/java/com/maeng0830/album/common/logging/LogTrace.java
+++ b/src/main/java/com/maeng0830/album/common/logging/LogTrace.java
@@ -1,0 +1,74 @@
+package com.maeng0830.album.common.logging;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class LogTrace {
+
+	private static final String START_PREFIX = "-->";
+	private static final String COMPLETE_PREFIX = "<--";
+	private static final String EX_PREFIX = "<X-";
+
+	private ThreadLocal<LogId> curLogId = new ThreadLocal<>();
+
+	public LogStatus begin(String message) {
+		syncLogId();
+
+		LogId logId = curLogId.get();
+		Long startTime = System.currentTimeMillis();
+
+		log.info("[{}] {}{}", logId.getId(), decorateLog(START_PREFIX, logId.getDepth()), message);
+
+		return new LogStatus(logId, startTime, message);
+	}
+
+	public void end(LogStatus status) {
+		complete(status, null);
+	}
+
+	public void exception(LogStatus status, Exception e) {
+		complete(status, e);
+	}
+
+	private void syncLogId() {
+		LogId logId = curLogId.get();
+
+		if (logId == null) {
+			curLogId.set(new LogId());
+		} else {
+			curLogId.set(logId.createNext());
+		}
+	}
+
+	private void complete(LogStatus status, Exception e) {
+		Long stopTimeMs = System.currentTimeMillis();
+		long resultTimeMs = stopTimeMs - status.getStartTime();
+		LogId logId = status.getLogId();
+
+		if (e == null) {
+			log.info("[{}] {}{} time={}ms", logId.getId(), decorateLog(COMPLETE_PREFIX, logId.getDepth()), status.getMessage(), resultTimeMs);
+		} else {
+			log.info("[{}] {}{} time={}ms ex={}", logId.getId(), decorateLog(EX_PREFIX, logId.getDepth()), status.getMessage(), resultTimeMs, e.toString());
+		}
+
+		releaseLogId();
+	}
+
+	private void releaseLogId() {
+		LogId logId = curLogId.get();
+		if (logId.isZeroDepth()) {
+			curLogId.remove();
+		} else {
+			curLogId.set(logId.createPrev());
+		}
+	}
+
+	private static String decorateLog(String prefix, int depth) {
+		StringBuilder sb = new StringBuilder();
+
+		for (int i = 0; i < depth; i++) {
+			sb.append( (i == depth - 1) ? "|" + prefix : "|   ");
+		}
+		return sb.toString();
+	}
+}

--- a/src/test/java/com/maeng0830/album/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/maeng0830/album/member/repository/MemberRepositoryTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.tuple;
 
 import com.maeng0830.album.member.domain.Member;
 import com.maeng0830.album.member.domain.MemberStatus;
+import com.maeng0830.album.member.repository.MemberRepository;
 import com.maeng0830.album.support.RepositoryTestSupport;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/maeng0830/album/member/service/MemberServiceTest.java
+++ b/src/test/java/com/maeng0830/album/member/service/MemberServiceTest.java
@@ -31,6 +31,7 @@ import com.maeng0830.album.member.dto.request.MemberPasswordModifiedForm;
 import com.maeng0830.album.member.dto.request.MemberWithdrawForm;
 import com.maeng0830.album.member.dto.request.Oauth2PasswordForm;
 import com.maeng0830.album.member.repository.MemberRepository;
+import com.maeng0830.album.member.service.MemberService;
 import com.maeng0830.album.security.dto.LoginType;
 import com.maeng0830.album.support.ServiceTestSupport;
 import java.io.File;

--- a/src/test/java/com/maeng0830/album/support/RepositoryTestSupport.java
+++ b/src/test/java/com/maeng0830/album/support/RepositoryTestSupport.java
@@ -1,14 +1,18 @@
 package com.maeng0830.album.support;
 
+import com.maeng0830.album.common.aop.AopConfig;
+import com.maeng0830.album.common.aop.aspect.LoggingAspect;
 import com.maeng0830.album.support.config.RepositoryTestConfig;
 import com.maeng0830.album.support.util.TestFileManager;
 import org.junit.jupiter.api.AfterEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
-@Import(RepositoryTestConfig.class)
+@EnableAspectJAutoProxy
+@Import({RepositoryTestConfig.class, AopConfig.class})
 @ActiveProfiles("test")
 @DataJpaTest
 public abstract class RepositoryTestSupport {

--- a/src/test/java/com/maeng0830/album/support/config/RepositoryTestConfig.java
+++ b/src/test/java/com/maeng0830/album/support/config/RepositoryTestConfig.java
@@ -1,10 +1,13 @@
 package com.maeng0830.album.support.config;
 
 import com.maeng0830.album.comment.repository.custom.CommentRepositoryImpl;
+import com.maeng0830.album.common.aop.AopConfig;
+import com.maeng0830.album.common.aop.aspect.LoggingAspect;
 import com.maeng0830.album.common.filedir.FileDir;
 import com.maeng0830.album.common.filedir.FileDirProperties;
 import com.maeng0830.album.common.image.DefaultImage;
 import com.maeng0830.album.common.image.DefaultImageProperties;
+import com.maeng0830.album.common.logging.LogTrace;
 import com.maeng0830.album.common.util.AlbumUtil;
 import com.maeng0830.album.feed.repository.custom.FeedRepositoryImpl;
 import com.maeng0830.album.follow.repository.custom.FollowRepositoryImpl;
@@ -12,10 +15,12 @@ import com.maeng0830.album.member.repository.custom.MemberRepositoryImpl;
 import com.maeng0830.album.support.util.TestFileManager;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import javax.persistence.EntityManager;
+import org.springframework.aop.aspectj.autoproxy.AspectJAwareAdvisorAutoProxyCreator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 
 @EnableConfigurationProperties(value = {FileDirProperties.class, DefaultImageProperties.class})
 @TestConfiguration


### PR DESCRIPTION
### 구현 내용  
- 스프링 AOP를 활용한 로그 기능 구현 
  - Persistence, Business, Presentation 계층의 public 메소드 호출 및 종료에 대한 로그를 남긴다. 
  - HTTP 클라이언트 요청 별로 로그를 구별할 수 있다. - 로그에는 메소드 정보, 메소드 호출 깊이, 수행 시간이 표현된다. - 메소드 정상 종료와 예외 종료를 구별할 수 있다.
  - @DataJpaTest를 사용하는 Repository 계층 테스트에서도 AOP가 적용될 수 있도록 설정 변경