### PR TITLE
피드 상세 조회 기능에 캐시 기능 적용

### DIFF
--- a/src/main/java/com/maeng0830/album/comment/controller/CommentController.java
+++ b/src/main/java/com/maeng0830/album/comment/controller/CommentController.java
@@ -13,7 +13,6 @@ import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -54,16 +53,15 @@ public class CommentController {
 		return commentService.modifiedComment(commentModifiedForm, albumUtil.checkLogin(principalDetails));
 	}
 
-	@PutMapping("/{domainId}/accuse")
-	public CommentAccuseDto accuseComment(@PathVariable Long domainId,
-										  @Valid @RequestBody CommentAccuseForm commentAccuseForm,
+	@PutMapping("/accuse")
+	public CommentAccuseDto accuseComment(@Valid @RequestBody CommentAccuseForm commentAccuseForm,
 										  @AuthenticationPrincipal PrincipalDetails principalDetails) {
-		return commentService.accuseComment(domainId, commentAccuseForm, albumUtil.checkLogin(principalDetails));
+		return commentService.accuseComment(commentAccuseForm, albumUtil.checkLogin(principalDetails));
 	}
 
-	@DeleteMapping("/{domainId}")
-	public BasicComment deleteComment(@PathVariable Long domainId,
+	@DeleteMapping("/{commentId}")
+	public BasicComment deleteComment(@PathVariable Long commentId,
 									  @AuthenticationPrincipal PrincipalDetails principalDetails) {
-		return commentService.deleteComment(domainId, albumUtil.checkLogin(principalDetails));
+		return commentService.deleteComment(commentId, albumUtil.checkLogin(principalDetails));
 	}
 }

--- a/src/main/java/com/maeng0830/album/comment/domain/CommentStatus.java
+++ b/src/main/java/com/maeng0830/album/comment/domain/CommentStatus.java
@@ -2,6 +2,7 @@ package com.maeng0830.album.comment.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.maeng0830.album.common.enumconvertor.EnumConvertor;
 import com.maeng0830.album.common.enumconvertor.EnumType;
 import lombok.AllArgsConstructor;
@@ -25,7 +26,7 @@ public enum CommentStatus implements EnumType {
 	}
 
 	@JsonCreator
-	public static CommentStatus from(@JsonProperty("commentStatus") String val){
+	public static CommentStatus from(String val){
 		for(CommentStatus commentStatus : CommentStatus.values()){
 			if(commentStatus.name().equals(val)){
 				return commentStatus;

--- a/src/main/java/com/maeng0830/album/comment/dto/request/CommentAccuseForm.java
+++ b/src/main/java/com/maeng0830/album/comment/dto/request/CommentAccuseForm.java
@@ -10,11 +10,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CommentAccuseForm {
 
+	@NotNull
+	private Long id;
 	@NotBlank
 	private String content;
 
 	@Builder
-	private CommentAccuseForm(String content) {
+	public CommentAccuseForm(Long id, String content) {
+		this.id = id;
 		this.content = content;
 	}
 }

--- a/src/main/java/com/maeng0830/album/comment/dto/request/CommentChangeStatusForm.java
+++ b/src/main/java/com/maeng0830/album/comment/dto/request/CommentChangeStatusForm.java
@@ -1,6 +1,6 @@
 package com.maeng0830.album.comment.dto.request;
 
-import javax.validation.constraints.NotBlank;
+import com.maeng0830.album.comment.domain.CommentStatus;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,19 +8,18 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class CommentModifiedForm {
+public class CommentChangeStatusForm {
 
 	@NotNull
 	private Long id;
-	@NotBlank
-	private String content;
+	private CommentStatus commentStatus;
 	@NotNull
 	private Long feedId;
 
 	@Builder
-	private CommentModifiedForm(Long id, String content, Long feedId) {
+	public CommentChangeStatusForm(Long id, CommentStatus commentStatus, Long feedId) {
 		this.id = id;
-		this.content = content;
+		this.commentStatus = commentStatus;
 		this.feedId = feedId;
 	}
 }

--- a/src/main/java/com/maeng0830/album/comment/dto/response/GroupComment.java
+++ b/src/main/java/com/maeng0830/album/comment/dto/response/GroupComment.java
@@ -6,9 +6,11 @@ import com.maeng0830.album.common.model.entity.BaseEntity;
 import com.maeng0830.album.member.dto.MemberDto;
 import java.util.List;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
+@NoArgsConstructor
 @SuperBuilder
 @Getter
 @Setter

--- a/src/main/java/com/maeng0830/album/common/redis/EmbeddedRedisConfig.java
+++ b/src/main/java/com/maeng0830/album/common/redis/EmbeddedRedisConfig.java
@@ -53,7 +53,7 @@ public class EmbeddedRedisConfig {
 			}
 		}
 
-		throw new IllegalArgumentException("Not Found Available port: 10000 ~ 65535");
+		throw new IllegalArgumentException("Not Found Available port: 16379 ~ 65535");
 	}
 
 	/**

--- a/src/main/java/com/maeng0830/album/common/redis/RedisConfig.java
+++ b/src/main/java/com/maeng0830/album/common/redis/RedisConfig.java
@@ -1,16 +1,31 @@
 package com.maeng0830.album.common.redis;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.session.data.redis.config.ConfigureRedisAction;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
+@EnableCaching // 캐시 기능 활성화
 @EnableRedisHttpSession(maxInactiveIntervalInSeconds = 300)
 @Configuration
 public class RedisConfig {
@@ -18,6 +33,39 @@ public class RedisConfig {
 	private String redisHost;
 	@Value("${spring.redis.port}")
 	private String redisPort;
+
+	private ObjectMapper redisObjectMapper() {
+		// local date time 역직렬화 위한 추가 코드
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+
+		// LinkedHasmap cannot be cast to class DTO Object 에러 해결을 위한 코드
+		BasicPolymorphicTypeValidator polymorphicTypeValidator = BasicPolymorphicTypeValidator.builder()
+				.allowIfSubType(Object.class)
+				.build();
+		objectMapper.activateDefaultTyping(polymorphicTypeValidator, DefaultTyping.NON_FINAL);
+
+		return objectMapper;
+	}
+
+	private RedisCacheConfiguration redisCacheDefaultConfig() {
+		// Redis Cache 기본 설정
+		return RedisCacheConfiguration.defaultCacheConfig()
+				.computePrefixWith(CacheKeyPrefix.simple())
+				.disableCachingNullValues()
+				.entryTtl(Duration.ofSeconds(300))
+				.serializeKeysWith(SerializationPair.fromSerializer(new StringRedisSerializer()))
+				.serializeValuesWith(
+						SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(redisObjectMapper())));
+	}
+
+	private Map<String, RedisCacheConfiguration> redisCacheConfigMap() {
+		// cacheName에 따른 Redis Cache 설정
+		Map<String, RedisCacheConfiguration> redisCacheConfigMap = new HashMap<>();
+		redisCacheConfigMap.put("feed", redisCacheDefaultConfig().entryTtl(Duration.ofSeconds(60)));
+
+		return redisCacheConfigMap;
+	}
 
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
@@ -33,9 +81,18 @@ public class RedisConfig {
 
 		redisTemplate.setConnectionFactory(redisConnectionFactory());
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
-		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer(redisObjectMapper()));
 
 		return redisTemplate;
+	}
+
+	@Bean
+	public RedisCacheManager redisCacheManager() {
+		return RedisCacheManager.RedisCacheManagerBuilder
+				.fromConnectionFactory(redisConnectionFactory())
+				.cacheDefaults(redisCacheDefaultConfig()) // 기본 캐시 설정
+				.withInitialCacheConfigurations(redisCacheConfigMap()) // cacheName에 따른 캐시 설정
+				.build();
 	}
 
 	@Bean

--- a/src/main/java/com/maeng0830/album/feed/controller/FeedController.java
+++ b/src/main/java/com/maeng0830/album/feed/controller/FeedController.java
@@ -59,10 +59,10 @@ public class FeedController {
 		return feedService.feed(feedPostForm, imageFiles, albumUtil.checkLogin(principalDetails));
 	}
 
-	@DeleteMapping("/{domainId}")
-	public FeedDto deleteFeed(@PathVariable Long domainId,
+	@DeleteMapping("/{feedId}")
+	public FeedDto deleteFeed(@PathVariable Long feedId,
 							  @AuthenticationPrincipal PrincipalDetails principalDetails) {
-		return feedService.deleteFeed(domainId, albumUtil.checkLogin(principalDetails));
+		return feedService.deleteFeed(feedId, albumUtil.checkLogin(principalDetails));
 	}
 
 	@PutMapping
@@ -73,11 +73,10 @@ public class FeedController {
 				albumUtil.checkLogin(principalDetails));
 	}
 
-	@PutMapping("/{domainId}/accuse")
-	public FeedAccuseDto accuseFeed(@PathVariable Long domainId,
-									@Valid @RequestBody FeedAccuseRequestForm feedAccuseRequestForm,
+	@PutMapping("/accuse")
+	public FeedResponse accuseFeed(@Valid @RequestBody FeedAccuseRequestForm feedAccuseRequestForm,
 									@AuthenticationPrincipal PrincipalDetails principalDetails) {
-		return feedService.accuseFeed(domainId, feedAccuseRequestForm, albumUtil.checkLogin(principalDetails));
+		return feedService.accuseFeed(feedAccuseRequestForm, albumUtil.checkLogin(principalDetails));
 	}
 
 	@GetMapping("/members/{memberId}")

--- a/src/main/java/com/maeng0830/album/feed/domain/FeedStatus.java
+++ b/src/main/java/com/maeng0830/album/feed/domain/FeedStatus.java
@@ -24,7 +24,7 @@ public enum FeedStatus implements EnumType {
 	}
 
 	@JsonCreator
-	public static FeedStatus from(@JsonProperty("feedStatus") String val){
+	public static FeedStatus from(String val){
 		for(FeedStatus feedStatus : FeedStatus.values()){
 			if(feedStatus.name().equals(val)){
 				return feedStatus;

--- a/src/main/java/com/maeng0830/album/feed/dto/request/FeedAccuseRequestForm.java
+++ b/src/main/java/com/maeng0830/album/feed/dto/request/FeedAccuseRequestForm.java
@@ -1,6 +1,7 @@
 package com.maeng0830.album.feed.dto.request;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,11 +10,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class FeedAccuseRequestForm {
 
+	@NotNull
+	private Long id;
 	@NotBlank
 	private String content;
 
 	@Builder
-	private FeedAccuseRequestForm(String content) {
+	public FeedAccuseRequestForm(Long id, String content) {
+		this.id = id;
 		this.content = content;
 	}
 }

--- a/src/main/java/com/maeng0830/album/feed/dto/request/FeedChangeStatusForm.java
+++ b/src/main/java/com/maeng0830/album/feed/dto/request/FeedChangeStatusForm.java
@@ -1,0 +1,23 @@
+package com.maeng0830.album.feed.dto.request;
+
+import com.maeng0830.album.feed.domain.FeedStatus;
+import com.maeng0830.album.member.domain.MemberStatus;
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FeedChangeStatusForm {
+
+	@NotNull
+	private Long id;
+	private FeedStatus feedStatus;
+
+	@Builder
+	public FeedChangeStatusForm(Long id, FeedStatus feedStatus) {
+		this.id = id;
+		this.feedStatus = feedStatus;
+	}
+}

--- a/src/main/java/com/maeng0830/album/feed/exception/FeedExceptionCode.java
+++ b/src/main/java/com/maeng0830/album/feed/exception/FeedExceptionCode.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum FeedExceptionCode implements ExceptionCode {
 	NOT_EXIST_FEED("피드가 존재하지 않습니다."),
+	DELETED_FEED("삭제된 피드입니다."),
 	NOT_EXIST_FEED_IMAGE("피드 이미지가 존재하지 않습니다.");
 
 	private final String description;

--- a/src/main/java/com/maeng0830/album/member/controller/AdminController.java
+++ b/src/main/java/com/maeng0830/album/member/controller/AdminController.java
@@ -2,6 +2,7 @@ package com.maeng0830.album.member.controller;
 
 import com.maeng0830.album.comment.domain.CommentStatus;
 import com.maeng0830.album.comment.dto.CommentAccuseDto;
+import com.maeng0830.album.comment.dto.request.CommentChangeStatusForm;
 import com.maeng0830.album.comment.dto.response.BasicComment;
 import com.maeng0830.album.comment.service.CommentService;
 import com.maeng0830.album.common.util.AlbumUtil;
@@ -9,12 +10,15 @@ import com.maeng0830.album.feed.domain.FeedStatus;
 import com.maeng0830.album.feed.dto.FeedAccuseDto;
 import com.maeng0830.album.feed.dto.FeedDto;
 import com.maeng0830.album.feed.dto.FeedResponse;
+import com.maeng0830.album.feed.dto.request.FeedChangeStatusForm;
 import com.maeng0830.album.feed.service.FeedService;
 import com.maeng0830.album.member.domain.MemberStatus;
 import com.maeng0830.album.member.dto.MemberDto;
+import com.maeng0830.album.member.dto.request.MemberChangeStatusForm;
 import com.maeng0830.album.member.service.MemberService;
 import com.maeng0830.album.security.formlogin.PrincipalDetails;
 import java.util.List;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -49,9 +53,9 @@ public class AdminController {
 		return feedService.getFeedAccuses(albumUtil.checkLogin(principalDetails), feedId);
 	}
 
-	@PutMapping("/feeds/{feedId}/status")
-	public FeedDto changeFeedStatus(@PathVariable Long feedId, @RequestBody FeedStatus feedStatus) {
-		return feedService.changeFeedStatus(feedId, feedStatus);
+	@PutMapping("/feeds/status")
+	public FeedDto changeFeedStatus(@Valid @RequestBody FeedChangeStatusForm feedChangeStatusForm) {
+		return feedService.changeFeedStatus(feedChangeStatusForm);
 	}
 
 	// Member
@@ -61,9 +65,9 @@ public class AdminController {
 		return memberService.getMembersForAdmin(albumUtil.checkLogin(principalDetails), searchText, pageable);
 	}
 
-	@PutMapping("/members/{memberId}/status")
-	public MemberDto changeMemberStatus(@PathVariable Long memberId, @RequestBody MemberStatus memberStatus) {
-		return memberService.changeMemberStatus(memberId, memberStatus);
+	@PutMapping("/members/status")
+	public MemberDto changeMemberStatus(@Valid @RequestBody MemberChangeStatusForm memberChangeStatusForm) {
+		return memberService.changeMemberStatus(memberChangeStatusForm);
 	}
 
 	// Comment
@@ -79,9 +83,8 @@ public class AdminController {
 		return commentService.getCommentAccuses(albumUtil.checkLogin(principalDetails), commentId);
 	}
 
-	@PutMapping("/comments/{commentId}/status")
-	public BasicComment changeCommentStatus(@PathVariable Long commentId,
-											@RequestBody CommentStatus commentStatus) {
-		return commentService.changeCommentStatus(commentId, commentStatus);
+	@PutMapping("/comments/status")
+	public BasicComment changeCommentStatus(@Valid @RequestBody CommentChangeStatusForm commentChangeStatusForm) {
+		return commentService.changeCommentStatus(commentChangeStatusForm);
 	}
 }

--- a/src/main/java/com/maeng0830/album/member/domain/MemberStatus.java
+++ b/src/main/java/com/maeng0830/album/member/domain/MemberStatus.java
@@ -26,7 +26,7 @@ public enum MemberStatus implements EnumType {
 	}
 
 	@JsonCreator
-	public static MemberStatus from(@JsonProperty("memberStatus") String val){
+	public static MemberStatus from(String val){
 		for(MemberStatus memberStatus : MemberStatus.values()){
 			if(memberStatus.name().equals(val)){
 				return memberStatus;

--- a/src/main/java/com/maeng0830/album/member/dto/request/MemberChangeStatusForm.java
+++ b/src/main/java/com/maeng0830/album/member/dto/request/MemberChangeStatusForm.java
@@ -1,0 +1,22 @@
+package com.maeng0830.album.member.dto.request;
+
+import com.maeng0830.album.member.domain.MemberStatus;
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberChangeStatusForm {
+
+	@NotNull
+	private Long id;
+	private MemberStatus memberStatus;
+
+	@Builder
+	public MemberChangeStatusForm(Long id, MemberStatus memberStatus) {
+		this.id = id;
+		this.memberStatus = memberStatus;
+	}
+}

--- a/src/main/java/com/maeng0830/album/member/service/MemberService.java
+++ b/src/main/java/com/maeng0830/album/member/service/MemberService.java
@@ -23,6 +23,7 @@ import com.maeng0830.album.member.domain.Member;
 import com.maeng0830.album.member.domain.MemberRole;
 import com.maeng0830.album.member.domain.MemberStatus;
 import com.maeng0830.album.member.dto.MemberDto;
+import com.maeng0830.album.member.dto.request.MemberChangeStatusForm;
 import com.maeng0830.album.member.dto.request.MemberJoinForm;
 import com.maeng0830.album.member.dto.request.MemberModifiedForm;
 import com.maeng0830.album.member.dto.request.MemberPasswordModifiedForm;
@@ -245,11 +246,11 @@ public class MemberService {
 	}
 
 	@Transactional
-	public MemberDto changeMemberStatus(Long id, MemberStatus memberStatus) {
-		Member findMember = memberRepository.findById(id).orElseThrow(() -> new AlbumException(
+	public MemberDto changeMemberStatus(MemberChangeStatusForm memberChangeStatusForm) {
+		Member findMember = memberRepository.findById(memberChangeStatusForm.getId()).orElseThrow(() -> new AlbumException(
 				NOT_EXIST_MEMBER));
 
-		findMember.changeStatus(memberStatus);
+		findMember.changeStatus(memberChangeStatusForm.getMemberStatus());
 
 		return MemberDto.from(findMember);
 	}

--- a/src/main/java/com/maeng0830/album/testData.java
+++ b/src/main/java/com/maeng0830/album/testData.java
@@ -89,11 +89,21 @@ public class testData {
 					.build());
 
 			// 피드 데이터 추가
-			Feed feed = feedRepository.save(Feed.builder()
-					.title("title" + i)
-					.member(member)
-					.status(FeedStatus.NORMAL)
-					.build());
+			Feed feed;
+			if (i == 0) {
+				feed = feedRepository.save(Feed.builder()
+						.title("title" + i)
+						.member(member)
+						.status(FeedStatus.NORMAL)
+						.commentCount(10)
+						.build());
+			} else {
+				feed = feedRepository.save(Feed.builder()
+						.title("title" + i)
+						.member(member)
+						.status(FeedStatus.NORMAL)
+						.build());
+			}
 
 			// 피드 이미지 데이터 추가
 			FeedImage feedImage = FeedImage.builder()

--- a/src/main/resources/static/js/adminComments.js
+++ b/src/main/resources/static/js/adminComments.js
@@ -34,6 +34,7 @@ function getAdminComments(currentPage, searchText) {
           var commentContent = c.content;
           var commentCreatedAt = c.createdAt;
           var commentStatus = c.status;
+          var feedId = c.feedId;
 
           commentHtml += `<div class="row row-cols-11 justify-content-md-center text-center">
                             <div class="col-1">${commentId}</div>
@@ -52,17 +53,17 @@ function getAdminComments(currentPage, searchText) {
                               <div class="row">
                                 <button 
                                   class="changeStatusBtn btn btn-outline-primary btn-sm" 
-                                  onclick="changeStatus(${commentId}, '${statusNormal}')">Normal</button>
+                                  onclick="changeStatus(${commentId}, '${statusNormal}', ${feedId})">Normal</button>
                               </div>
                               <div class="row">
                                 <button 
                                   class="changeStatusBtn btn btn-outline-primary btn-sm" 
-                                  onclick="changeStatus(${commentId}, '${statusAccuse}')">Accuse</button>
+                                  onclick="changeStatus(${commentId}, '${statusAccuse}', ${feedId})">Accuse</button>
                               </div>
                               <div class="row">
                                 <button 
                                   class="changeStatusBtn btn btn-outline-primary btn-sm" 
-                                  onclick="changeStatus(${commentId}, '${statusDelete}')">Delete</button>
+                                  onclick="changeStatus(${commentId}, '${statusDelete}', ${feedId})">Delete</button>
                               </div>
                             </div>
                         </div>
@@ -137,13 +138,15 @@ function pageLink(currentPage, totalPage, searchText, funcName) {
 }
 
 // 상태 변경
-function changeStatus(commentId, status) {
+function changeStatus(commentId, status, feedId) {
   console.log('changeStatus 호출');
 
-  var url = `/admin/comments/${commentId}/status`;
+  var url = `/admin/comments/status`;
 
   var commentStatus = {
-    commentStatus: status
+    id: commentId,
+    commentStatus: status,
+    feedId: feedId
   }
 
   $.ajax({

--- a/src/main/resources/static/js/adminFeeds.js
+++ b/src/main/resources/static/js/adminFeeds.js
@@ -140,9 +140,10 @@ function pageLink(currentPage, totalPage, searchText, funcName) {
 function changeStatus(feedId, status) {
   console.log('changeStatus 호출');
 
-  var url = `/admin/feeds/${feedId}/status`;
+  var url = `/admin/feeds/status`;
 
   var feedStatus = {
+    id: feedId,
     feedStatus: status
   }
 

--- a/src/main/resources/static/js/adminMembers.js
+++ b/src/main/resources/static/js/adminMembers.js
@@ -134,9 +134,10 @@ function pageLink(currentPage, totalPage, searchText, funcName) {
 function changeStatus(memberId, status) {
   console.log('changeStatus 호출');
 
-  var url = `/admin/members/${memberId}/status`;
+  var url = `/admin/members/status`;
 
   var memberStatus = {
+    id: memberId,
     memberStatus: status
   }
 

--- a/src/main/resources/static/js/feedPage.js
+++ b/src/main/resources/static/js/feedPage.js
@@ -27,7 +27,7 @@ function getFeed(feedId, loginId) {
         buttonsHtml = `
               <button class="btn btn-sm btn-outline-primary me-2" onclick="location.href='/members/modified-feed/${feedId}';">수정</button>
               <button class="btn btn-sm btn-outline-danger" onclick="deleteFeedOrComment('feeds', ${feedId})">삭제</button>`;
-      } else if (loginId !== -1) {
+      } else if (loginId !== feedMemberId) {
         // 로그인한 사용자와 댓글 작성자의 memberId가 일치하지 않는 경우
         buttonsHtml = `
               <button class="btn btn-sm btn-outline-danger" onclick="accuseTemplate('feeds', ${feedId})">신고</button>`;
@@ -145,7 +145,7 @@ function getComments(feedId, currentPage, loginId) {
             if (loginId === memberId) {
               // 로그인한 사용자와 댓글 작성자의 memberId가 일치하는 경우
               buttonsHtml = `
-              <button class="btn btn-sm btn-outline-primary me-2" onclick="modifiedCommentTemplate(${commentId}, '${content}')">수정</button>
+              <button class="btn btn-sm btn-outline-primary me-2" onclick="modifiedCommentTemplate(${commentId}, '${content}', ${feedId})">수정</button>
               <button class="btn btn-sm btn-outline-danger" onclick="deleteFeedOrComment('comments', ${commentId})">삭제</button>`;
             } else if (loginId !== -1) {
               // 로그인한 사용자와 댓글 작성자의 memberId가 일치하지 않는 경우
@@ -204,7 +204,7 @@ function getComments(feedId, currentPage, loginId) {
               if (loginId === memberId) {
                 // 로그인한 사용자와 댓글 작성자의 memberId가 일치하는 경우
                 buttonsHtml = `
-              <button class="btn btn-sm btn-outline-primary me-2" onclick="modifiedCommentTemplate(${commentId}, '${content}')">수정</button>
+              <button class="btn btn-sm btn-outline-primary me-2" onclick="modifiedCommentTemplate(${commentId}, '${content}', ${feedId})">수정</button>
               <button class="btn btn-sm btn-outline-danger" onclick="deleteFeedOrComment('comments', ${commentId})">삭제</button>`;
               } else if (loginId !== -1) {
                 // 로그인한 사용자와 댓글 작성자의 memberId가 일치하지 않는 경우
@@ -346,7 +346,7 @@ function postCommentReply(feedId, groupId, parentId, content) {
 }
 
 // 댓글 수정 모달
-function modifiedCommentTemplate(id, prevContent) {
+function modifiedCommentTemplate(id, prevContent, feedId) {
   console.log('modifiedTemplate 호출');
 
   var modifiedTemplateHtml = `
@@ -361,7 +361,7 @@ function modifiedCommentTemplate(id, prevContent) {
                         <input type="text" class="form-control rounded-3" name="content" id="content" value="${prevContent}">
                         <label for="content">수정 내용</label>
                       </div>
-                      <button class="w-100 mb-2 btn btn-lg rounded-3 btn-primary text-center" onclick="putModifiedComment(${id}, $('#content').val())">댓글 수정</button>
+                      <button class="w-100 mb-2 btn btn-lg rounded-3 btn-primary text-center" onclick="putModifiedComment(${id}, $('#content').val(), ${feedId})">댓글 수정</button>
                    </div>`;
 
   console.log(modifiedTemplateHtml);
@@ -370,10 +370,11 @@ function modifiedCommentTemplate(id, prevContent) {
 }
 
 // 댓글 수정
-function putModifiedComment(id, content) {
+function putModifiedComment(id, content, feedId) {
   var commentModifiedForm = {
     id: id,
-    content: content
+    content: content,
+    feedId: feedId
   }
 
   $.ajax({
@@ -409,7 +410,7 @@ function deleteFeedOrComment(domain, id) {
           alert(response.message);
         } else {
           alert("삭제 되었습니다.");
-          if (domain == 'feed') {
+          if (`${domain}` == 'feeds') {
             location.href = "/";
           } else {
             location.reload();
@@ -449,13 +450,14 @@ function accuseTemplate(domain, id) {
   $('#accuseTemplate').modal('show');
 }
 
-// 신고 등록
+// 피드 및 댓글 신고 등록
 function postAccuse(domain, id, content) {
-  var url = `/${domain}/${id}/accuse`;
+  var url = `/${domain}/accuse`;
 
   var jsonData = {
+    id: id,
     content: content
-  }
+  };
 
   $.ajax({
     type: 'PUT',
@@ -468,7 +470,7 @@ function postAccuse(domain, id, content) {
         alert(response.message);
       } else {
         alert("신고 제출이 완료되었습니다.");
-        location.reload();
+          location.reload();
       }
     },
     error: function () {

--- a/src/test/java/com/maeng0830/album/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/maeng0830/album/comment/service/CommentServiceTest.java
@@ -15,6 +15,7 @@ import com.maeng0830.album.comment.domain.CommentAccuse;
 import com.maeng0830.album.comment.domain.CommentStatus;
 import com.maeng0830.album.comment.dto.CommentAccuseDto;
 import com.maeng0830.album.comment.dto.request.CommentAccuseForm;
+import com.maeng0830.album.comment.dto.request.CommentChangeStatusForm;
 import com.maeng0830.album.comment.dto.request.CommentModifiedForm;
 import com.maeng0830.album.comment.dto.request.CommentPostForm;
 import com.maeng0830.album.comment.dto.response.BasicComment;
@@ -294,6 +295,7 @@ class CommentServiceTest extends ServiceTestSupport {
 		// BasicComment 세팅
 		CommentModifiedForm commentModifiedForm = CommentModifiedForm.builder()
 				.id(comment.getId())
+				.feedId(feed.getId())
 				.content("modifiedContent")
 				.build();
 
@@ -382,8 +384,9 @@ class CommentServiceTest extends ServiceTestSupport {
 		comment.saveParent(comment);
 		commentRepository.save(comment);
 
-		// CommentAccuseDto 세팅
+		// CommentAccuseForm 세팅
 		CommentAccuseForm commentAccuseForm = CommentAccuseForm.builder()
+				.id(comment.getId())
 				.content("testContent")
 				.build();
 
@@ -391,8 +394,7 @@ class CommentServiceTest extends ServiceTestSupport {
 		MemberDto memberDto = MemberDto.from(commentNoWriter);
 
 		// when
-		CommentAccuseDto result = commentService.accuseComment(comment.getId(), commentAccuseForm,
-				memberDto);
+		CommentAccuseDto result = commentService.accuseComment(commentAccuseForm, memberDto);
 
 		// then
 		assertThat(result).extracting("comment.id", "member.id", "content")
@@ -511,8 +513,15 @@ class CommentServiceTest extends ServiceTestSupport {
 		comment.saveParent(comment);
 		commentRepository.save(comment);
 
+		// CommentChangeStatusForm 세팅
+		CommentChangeStatusForm commentChangeStatusForm = CommentChangeStatusForm.builder()
+				.id(comment.getId())
+				.feedId(feed.getId())
+				.commentStatus(commentStatus)
+				.build();
+
 		// when
-		BasicComment result = commentService.changeCommentStatus(comment.getId(), commentStatus);
+		BasicComment result = commentService.changeCommentStatus(commentChangeStatusForm);
 
 		// then
 		assertThat(result).extracting("id", "status")

--- a/src/test/java/com/maeng0830/album/docs/AdminControllerDocsTest.java
+++ b/src/test/java/com/maeng0830/album/docs/AdminControllerDocsTest.java
@@ -14,29 +14,31 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.maeng0830.album.comment.domain.CommentStatus;
 import com.maeng0830.album.comment.dto.CommentAccuseDto;
 import com.maeng0830.album.comment.dto.CommentDto;
+import com.maeng0830.album.comment.dto.request.CommentChangeStatusForm;
 import com.maeng0830.album.comment.dto.response.BasicComment;
 import com.maeng0830.album.common.model.image.Image;
 import com.maeng0830.album.feed.domain.FeedStatus;
 import com.maeng0830.album.feed.dto.FeedAccuseDto;
 import com.maeng0830.album.feed.dto.FeedDto;
 import com.maeng0830.album.feed.dto.FeedResponse;
+import com.maeng0830.album.feed.dto.request.FeedChangeStatusForm;
 import com.maeng0830.album.member.domain.MemberRole;
 import com.maeng0830.album.member.domain.MemberStatus;
 import com.maeng0830.album.member.dto.MemberDto;
+import com.maeng0830.album.member.dto.request.MemberChangeStatusForm;
 import com.maeng0830.album.security.dto.LoginType;
 import com.maeng0830.album.support.DocsTestSupport;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
@@ -396,8 +398,10 @@ public class AdminControllerDocsTest extends DocsTestSupport {
 	@Test
 	void changeFeedStatus() throws Exception {
 		// given
-		Map<String, String> map = new HashMap<>();
-		map.put("feedStatus", "DELETE");
+		FeedChangeStatusForm feedChangeStatusForm = FeedChangeStatusForm.builder()
+				.feedStatus(FeedStatus.DELETE)
+				.id(1L)
+				.build();
 
 		MemberDto feedWriter = MemberDto.builder()
 				.id(3L)
@@ -416,19 +420,19 @@ public class AdminControllerDocsTest extends DocsTestSupport {
 				.build();
 
 		FeedDto feedDto = FeedDto.builder()
-				.id(1L)
+				.id(feedChangeStatusForm.getId())
 				.title("testTitle")
 				.content("content")
 				.hits(1)
 				.commentCount(1)
-				.status(FeedStatus.DELETE)
+				.status(feedChangeStatusForm.getFeedStatus())
 				.memberDto(feedWriter)
 				.createdAt(LocalDateTime.now())
 				.modifiedAt(LocalDateTime.now())
 				.modifiedBy(feedWriter.getUsername())
 				.build();
 
-		given(feedService.changeFeedStatus(any(Long.class), any(FeedStatus.class)))
+		given(feedService.changeFeedStatus(any(FeedChangeStatusForm.class)))
 				.willReturn(
 						feedDto
 				);
@@ -436,9 +440,9 @@ public class AdminControllerDocsTest extends DocsTestSupport {
 
 		// then
 		mockMvc.perform(
-						RestDocumentationRequestBuilders.put("/admin/feeds/{feedId}/status", 1)
+						put("/admin/feeds/status")
 								.with(user(adminPrincipalDetails))
-								.content(objectMapper.writeValueAsString(map))
+								.content(objectMapper.writeValueAsString(feedChangeStatusForm))
 								.contentType(MediaType.APPLICATION_JSON)
 				)
 				.andDo(print())
@@ -446,10 +450,8 @@ public class AdminControllerDocsTest extends DocsTestSupport {
 				.andDo(document("change-feed-status-for-admin",
 						preprocessRequest(prettyPrint()),
 						preprocessResponse(prettyPrint()),
-						pathParameters(
-								parameterWithName("feedId").description("피드 번호")
-						),
 						requestFields(
+								fieldWithPath("id").description("피드 번호"),
 								fieldWithPath("feedStatus").description("변경할 상태")
 						),
 						responseFields(
@@ -604,8 +606,10 @@ public class AdminControllerDocsTest extends DocsTestSupport {
 	@Test
 	void changeMemberStatus() throws Exception {
 		// given
-		Map<String, String> map = new HashMap<>();
-		map.put("memberStatus", "LOCKED");
+		MemberChangeStatusForm memberChangeStatusForm = MemberChangeStatusForm.builder()
+				.id(3L)
+				.memberStatus(MemberStatus.LOCKED)
+				.build();
 
 		MemberDto memberDto = MemberDto.builder()
 				.id(3L)
@@ -623,7 +627,7 @@ public class AdminControllerDocsTest extends DocsTestSupport {
 				.modifiedBy("member@naver.com")
 				.build();
 
-		given(memberService.changeMemberStatus(any(Long.class), any(MemberStatus.class)))
+		given(memberService.changeMemberStatus(any(MemberChangeStatusForm.class)))
 				.willReturn(
 						memberDto
 				);
@@ -631,9 +635,9 @@ public class AdminControllerDocsTest extends DocsTestSupport {
 
 		// then
 		mockMvc.perform(
-						RestDocumentationRequestBuilders.put("/admin/members/{memberId}/status", 3)
+						put("/admin/members/status")
 								.with(user(adminPrincipalDetails))
-								.content(objectMapper.writeValueAsString(map))
+								.content(objectMapper.writeValueAsString(memberChangeStatusForm))
 								.contentType(MediaType.APPLICATION_JSON)
 				)
 				.andDo(print())
@@ -641,10 +645,8 @@ public class AdminControllerDocsTest extends DocsTestSupport {
 				.andDo(document("change-member-status-for-admin",
 						preprocessRequest(prettyPrint()),
 						preprocessResponse(prettyPrint()),
-						pathParameters(
-								parameterWithName("memberId").description("회원 번호")
-						),
 						requestFields(
+								fieldWithPath("id").description("회원 번호"),
 								fieldWithPath("memberStatus").description("변경할 상태")
 						),
 						responseFields(
@@ -1073,8 +1075,11 @@ public class AdminControllerDocsTest extends DocsTestSupport {
 	@Test
 	void changeCommentStatus() throws Exception {
 		// given
-		Map<String, String> map = new HashMap<>();
-		map.put("commentStatus", "DELETE");
+		CommentChangeStatusForm commentChangeStatusForm = CommentChangeStatusForm.builder()
+				.id(1L)
+				.feedId(1L)
+				.commentStatus(CommentStatus.DELETE)
+				.build();
 
 		MemberDto writer = MemberDto.builder()
 				.id(3L)
@@ -1100,34 +1105,32 @@ public class AdminControllerDocsTest extends DocsTestSupport {
 				.parentMember(writer.getNickname())
 				.member(writer)
 				.content("testContent")
-				.status(CommentStatus.DELETE)
+				.status(commentChangeStatusForm.getCommentStatus())
 				.createdAt(LocalDateTime.now())
 				.modifiedAt(LocalDateTime.now())
 				.modifiedBy(writer.getUsername())
 				.build();
 
-		given(commentService.changeCommentStatus(any(Long.class), any(CommentStatus.class)))
+		given(commentService.changeCommentStatus(any(CommentChangeStatusForm.class)))
 				.willReturn(
 						basicComment
 				);
 		// when
 
 		// then
-		mockMvc.perform(
-						RestDocumentationRequestBuilders.put("/admin/comments/{commentId}/status", 1)
-								.with(user(adminPrincipalDetails))
-								.content(objectMapper.writeValueAsString(map))
-								.contentType(MediaType.APPLICATION_JSON)
+		mockMvc.perform(put("/admin/comments/status")
+						.with(user(adminPrincipalDetails))
+						.content(objectMapper.writeValueAsString(commentChangeStatusForm))
+						.contentType(MediaType.APPLICATION_JSON)
 				)
 				.andDo(print())
 				.andExpect(status().isOk())
 				.andDo(document("change-comment-status-for-admin",
 						preprocessRequest(prettyPrint()),
 						preprocessResponse(prettyPrint()),
-						pathParameters(
-								parameterWithName("commentId").description("댓글 번호")
-						),
 						requestFields(
+								fieldWithPath("id").description("댓글 번호"),
+								fieldWithPath("feedId").description("피드 번호"),
 								fieldWithPath("commentStatus").description("변경할 상태")
 						),
 						responseFields(

--- a/src/test/java/com/maeng0830/album/docs/CommentControllerDocsTest.java
+++ b/src/test/java/com/maeng0830/album/docs/CommentControllerDocsTest.java
@@ -437,6 +437,7 @@ public class CommentControllerDocsTest extends DocsTestSupport {
 
 		CommentModifiedForm commentModifiedForm = CommentModifiedForm.builder()
 				.id(1L)
+				.feedId(1L)
 				.content("modifiedContent")
 				.build();
 
@@ -474,6 +475,7 @@ public class CommentControllerDocsTest extends DocsTestSupport {
 						preprocessResponse(prettyPrint()),
 						requestFields(
 								fieldWithPath("id").description("댓글 번호"),
+								fieldWithPath("feedId").description("피드 번호"),
 								fieldWithPath("content").description("수정 댓글 내용")
 						),
 						responseFields(
@@ -516,6 +518,7 @@ public class CommentControllerDocsTest extends DocsTestSupport {
 	void accuseComment() throws Exception {
 		// given
 		CommentAccuseForm commentAccuseForm = CommentAccuseForm.builder()
+				.id(1L)
 				.content("accuseContent")
 				.build();
 
@@ -587,7 +590,7 @@ public class CommentControllerDocsTest extends DocsTestSupport {
 				.modifiedBy(memberPrincipalDetails.getMemberDto().getUsername())
 				.build();
 
-		given(commentService.accuseComment(any(Long.class), any(CommentAccuseForm.class), any()))
+		given(commentService.accuseComment(any(CommentAccuseForm.class), any()))
 				.willReturn(
 						commentAccuseDto
 				);
@@ -595,7 +598,7 @@ public class CommentControllerDocsTest extends DocsTestSupport {
 
 		// then
 		mockMvc.perform(
-						RestDocumentationRequestBuilders.put("/comments/{commentId}/accuse", 1)
+						RestDocumentationRequestBuilders.put("/comments/accuse")
 								.with(user(memberPrincipalDetails))
 								.content(objectMapper.writeValueAsString(commentAccuseForm))
 								.contentType(APPLICATION_JSON)
@@ -605,10 +608,8 @@ public class CommentControllerDocsTest extends DocsTestSupport {
 				.andDo(document("accuse-comment",
 						preprocessRequest(prettyPrint()),
 						preprocessResponse(prettyPrint()),
-						pathParameters(
-								parameterWithName("commentId").description("댓글 번호")
-						),
 						requestFields(
+								fieldWithPath("id").description("댓글 번호"),
 								fieldWithPath("content").description("신고 내용")
 						),
 						responseFields(

--- a/src/test/java/com/maeng0830/album/feed/controller/FeedControllerTest.java
+++ b/src/test/java/com/maeng0830/album/feed/controller/FeedControllerTest.java
@@ -326,6 +326,7 @@ class FeedControllerTest extends ControllerTestSupport {
 	void accuseFeed() throws Exception {
 		// given
 		FeedAccuseRequestForm feedAccuseRequestForm = FeedAccuseRequestForm.builder()
+				.id(1L)
 				.content("testContent")
 				.build();
 
@@ -333,7 +334,7 @@ class FeedControllerTest extends ControllerTestSupport {
 
 		// then
 		mockMvc.perform(
-						put("/feeds/1/accuse")
+						put("/feeds/accuse")
 								.with(csrf())
 								.with(user(memberPrincipalDetails))
 								.content(objectMapper.writeValueAsString(feedAccuseRequestForm))
@@ -348,13 +349,14 @@ class FeedControllerTest extends ControllerTestSupport {
 	void accuseFeed_blankContent() throws Exception {
 		// given
 		FeedAccuseRequestForm feedAccuseRequestForm = FeedAccuseRequestForm.builder()
+				.id(1L)
 				.build();
 
 		// when
 
 		// then
 		mockMvc.perform(
-						put("/feeds/1/accuse")
+						put("/feeds/accuse")
 								.with(csrf())
 								.with(user(memberPrincipalDetails))
 								.content(objectMapper.writeValueAsString(feedAccuseRequestForm))

--- a/src/test/java/com/maeng0830/album/feed/service/FeedServiceTest.java
+++ b/src/test/java/com/maeng0830/album/feed/service/FeedServiceTest.java
@@ -24,6 +24,7 @@ import com.maeng0830.album.feed.dto.FeedAccuseDto;
 import com.maeng0830.album.feed.dto.FeedDto;
 import com.maeng0830.album.feed.dto.FeedResponse;
 import com.maeng0830.album.feed.dto.request.FeedAccuseRequestForm;
+import com.maeng0830.album.feed.dto.request.FeedChangeStatusForm;
 import com.maeng0830.album.feed.dto.request.FeedModifiedForm;
 import com.maeng0830.album.feed.dto.request.FeedPostForm;
 import com.maeng0830.album.feed.repository.FeedAccuseRepository;
@@ -446,14 +447,17 @@ class FeedServiceTest extends ServiceTestSupport {
 		Feed feed1 = Feed.builder()
 				.member(member)
 				.title("feed1")
+				.status(NORMAL)
 				.build();
 		Feed feed2 = Feed.builder()
 				.member(member)
 				.title("feed1")
+				.status(NORMAL)
 				.build();
 		Feed feed3 = Feed.builder()
 				.member(member)
 				.title("feed1")
+				.status(NORMAL)
 				.build();
 		feedRepository.saveAll(List.of(feed1, feed2, feed3));
 
@@ -753,17 +757,18 @@ class FeedServiceTest extends ServiceTestSupport {
 
 		// feedAccuse 세팅
 		FeedAccuseRequestForm feedAccuseRequestForm = FeedAccuseRequestForm.builder()
+				.id(feed.getId())
 				.content("testContent")
 				.build();
 
 		// when
-		FeedAccuseDto result = feedService.accuseFeed(feed.getId(), feedAccuseRequestForm,
+		FeedResponse result = feedService.accuseFeed(feedAccuseRequestForm,
 				loginMemberDto);
 
 		// then
 		assertThat(result)
-				.extracting("content", "feedDto.status")
-				.containsExactlyInAnyOrder(feedAccuseRequestForm.getContent(), ACCUSE);
+				.extracting("id", "status")
+				.containsExactlyInAnyOrder(feed.getId(), ACCUSE);
 	}
 
 	@DisplayName("피드를 특정 상태로 변경할 수 있다.")
@@ -785,8 +790,14 @@ class FeedServiceTest extends ServiceTestSupport {
 				.build();
 		feedRepository.save(feed);
 
+		// FeedChangeStatusForm 세팅
+		FeedChangeStatusForm feedChangeStatusForm = FeedChangeStatusForm.builder()
+				.feedStatus(feedStatus)
+				.id(feed.getId())
+				.build();
+
 		// when
-		FeedDto feedDto = feedService.changeFeedStatus(feed.getId(), feedStatus);
+		FeedDto feedDto = feedService.changeFeedStatus(feedChangeStatusForm);
 
 		// then
 		assertThat(feedDto)

--- a/src/test/java/com/maeng0830/album/member/controller/AdminControllerTest.java
+++ b/src/test/java/com/maeng0830/album/member/controller/AdminControllerTest.java
@@ -8,6 +8,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.maeng0830.album.comment.domain.CommentStatus;
+import com.maeng0830.album.comment.dto.request.CommentChangeStatusForm;
+import com.maeng0830.album.feed.domain.FeedStatus;
+import com.maeng0830.album.feed.dto.request.FeedChangeStatusForm;
+import com.maeng0830.album.member.domain.MemberStatus;
+import com.maeng0830.album.member.dto.request.MemberChangeStatusForm;
 import com.maeng0830.album.support.ControllerTestSupport;
 import java.util.HashMap;
 import java.util.Map;
@@ -53,17 +59,19 @@ class AdminControllerTest extends ControllerTestSupport {
 	@Test
 	void changeFeedStatus() throws Exception {
 		// given
-		Map<String, String> map = new HashMap<>();
-		map.put("feedStatus", "DELETE");
+		FeedChangeStatusForm feedChangeStatusForm = FeedChangeStatusForm.builder()
+				.id(1L)
+				.feedStatus(FeedStatus.ACCUSE)
+				.build();
 
 		// when
 
 		// then
 		mockMvc.perform(
-						put("/admin/feeds/1/status")
+						put("/admin/feeds/status")
 								.with(csrf())
 								.with(user(adminPrincipalDetails))
-								.content(objectMapper.writeValueAsString(map))
+								.content(objectMapper.writeValueAsString(feedChangeStatusForm))
 								.contentType(APPLICATION_JSON)
 				)
 				.andDo(print())
@@ -110,17 +118,20 @@ class AdminControllerTest extends ControllerTestSupport {
 	@Test
 	void changeCommentStatus() throws Exception {
 		// given
-		Map<String, String> map = new HashMap<>();
-		map.put("commentStatus", "DELETE");
+		CommentChangeStatusForm commentChangeStatusForm = CommentChangeStatusForm.builder()
+				.id(1L)
+				.feedId(1L)
+				.commentStatus(CommentStatus.DELETE)
+				.build();
 
 		// when
 
 		// then
 		mockMvc.perform(
-						put("/admin/comments/1/status")
+						put("/admin/comments/status")
 								.with(csrf())
 								.with(user(adminPrincipalDetails))
-								.content(objectMapper.writeValueAsString(map))
+								.content(objectMapper.writeValueAsString(commentChangeStatusForm))
 								.contentType(APPLICATION_JSON)
 				)
 				.andDo(print())
@@ -150,17 +161,19 @@ class AdminControllerTest extends ControllerTestSupport {
 	@Test
 	void changeMemberStatus() throws Exception {
 		// given
-		Map<String, String> map = new HashMap<>();
-		map.put("memberStatus", "LOCKED");
+		MemberChangeStatusForm memberChangeStatusForm = MemberChangeStatusForm.builder()
+				.id(1L)
+				.memberStatus(MemberStatus.LOCKED)
+				.build();
 
 		// when
 
 		// then
 		mockMvc.perform(
-						put("/admin/members/1/status")
+						put("/admin/members/status")
 								.with(csrf())
 								.with(user(adminPrincipalDetails))
-								.content(objectMapper.writeValueAsString(map))
+								.content(objectMapper.writeValueAsString(memberChangeStatusForm))
 								.contentType(APPLICATION_JSON)
 				)
 				.andDo(print())

--- a/src/test/java/com/maeng0830/album/member/service/MemberServiceTest.java
+++ b/src/test/java/com/maeng0830/album/member/service/MemberServiceTest.java
@@ -25,6 +25,7 @@ import com.maeng0830.album.common.model.image.Image;
 import com.maeng0830.album.member.domain.Member;
 import com.maeng0830.album.member.domain.MemberStatus;
 import com.maeng0830.album.member.dto.MemberDto;
+import com.maeng0830.album.member.dto.request.MemberChangeStatusForm;
 import com.maeng0830.album.member.dto.request.MemberJoinForm;
 import com.maeng0830.album.member.dto.request.MemberModifiedForm;
 import com.maeng0830.album.member.dto.request.MemberPasswordModifiedForm;
@@ -613,8 +614,14 @@ class MemberServiceTest extends ServiceTestSupport {
 				.build();
 		memberRepository.save(member);
 
+		// MemberChangeStatusForm 세팅
+		MemberChangeStatusForm memberChangeStatusForm = MemberChangeStatusForm.builder()
+				.id(member.getId())
+				.memberStatus(status)
+				.build();
+
 		//when
-		MemberDto result = memberService.changeMemberStatus(member.getId(), status);
+		MemberDto result = memberService.changeMemberStatus(memberChangeStatusForm);
 
 		//then
 		assertThat(result.getId()).isEqualTo(member.getId());


### PR DESCRIPTION
### 구현 내용  
  - 피드 상세 조회 기능에 필요한 데이터 중 피드 데이터에 대해 캐시를 적용하였다.
  - Redis를 캐시 서버로 활용하였다.
  - FeedService.getFeed(), FeedService.deleteFeed(), FeedService.modifiedFeed(), FeedService.accuseFeed(), FeedService.changeFeedStatus() 메소드에 캐시 애노테이션을 적용하였다.
  - 캐시 기능을 통해 피드 데이터를 조회하기 위한 DB 접근 횟수, 비즈니스 로직 구동 횟수를 줄일 수 있었다.
  - 관련 테스트 코드를 수정하였다.