### PR TITLE
컬렉션 페치 조인의 페이징 문제 해결

### DIFF
--- a/src/main/java/com/maeng0830/album/feed/controller/FeedController.java
+++ b/src/main/java/com/maeng0830/album/feed/controller/FeedController.java
@@ -42,7 +42,7 @@ public class FeedController {
 			if (principalDetails != null) {
 				return feedService.getFeedsForMain(principalDetails.getMemberDto(), pageable);
 			} else {
-				return feedService.getFeedsForAdmin(null, pageable);
+				return feedService.getFeedsForMain(null, pageable);
 			}
 		} else {
 			return feedService.getFeedsForMainWithSearchText(searchText, pageable);

--- a/src/main/java/com/maeng0830/album/feed/repository/FeedRepository.java
+++ b/src/main/java/com/maeng0830/album/feed/repository/FeedRepository.java
@@ -14,6 +14,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface FeedRepository extends JpaRepository<Feed, Long>, FeedRepositoryCustom {
 
-	@EntityGraph(attributePaths = {"member", "feedImages"})
+	@EntityGraph(attributePaths = {"member"})
 	Page<Feed> findByStatusInAndMember_Id(Collection<FeedStatus> statuses, Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/maeng0830/album/feed/repository/custom/FeedRepositoryImpl.java
+++ b/src/main/java/com/maeng0830/album/feed/repository/custom/FeedRepositoryImpl.java
@@ -29,9 +29,8 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
 										Collection<String> createdBy, Pageable pageable) {
 
 		List<Feed> content = jpaQueryFactory
-				.select(feed).distinct()
+				.select(feed)
 				.from(feed)
-				.leftJoin(feed.feedImages, feedImage).fetchJoin()
 				.leftJoin(feed.member, member).fetchJoin()
 				.where(searchByCreatedByCondition(status, createdBy))
 				.orderBy(albumUtil.getOrderSpecifier(pageable.getSort(), feed))
@@ -51,9 +50,8 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
 	public Page<Feed> searchBySearchText(Collection<FeedStatus> status, String searchText,
 										 Pageable pageable) {
 		List<Feed> content = jpaQueryFactory
-				.select(feed).distinct()
+				.select(feed)
 				.from(feed)
-				.leftJoin(feed.feedImages, feedImage).fetchJoin()
 				.leftJoin(feed.member, member).fetchJoin()
 				.where(searchBySearchTextCondition(status, searchText))
 				.orderBy(albumUtil.getOrderSpecifier(pageable.getSort(), feed))

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -11,6 +11,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        default_batch_fetch_size: 100
 
   redis:
     host: ${local.redis.host}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,6 +19,7 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MariaDBDialect
+        default_batch_fetch_size: 100
 
   redis:
     host: ${aws.redis.host}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -11,6 +11,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        default_batch_fetch_size: 100
 
   redis:
     host: ${local.redis.host}


### PR DESCRIPTION
### 구현 내용
- hibernate.default_batch_fetch_size 기능을 활성화하였다.
- 페이징이 사용되는 Repository 메소드에서 컬렉션 페치 조인과 관련된 코드를 제거했다.
- 컬렉션 페치 조인으로 인한 중복 데이터가 생성되지 않을 것이므로 distinct를 제거했다.